### PR TITLE
chore: export react and server specific builds

### DIFF
--- a/.changeset/shaggy-ears-walk.md
+++ b/.changeset/shaggy-ears-walk.md
@@ -1,0 +1,5 @@
+---
+"remix-session-csrf": major
+---
+
+**[BREAKING]** use separate packages for exports (`remix-session-csrf/react`, `remix-session-csrf/server`) instead of single export (`remix-session-csrf`)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,4 +112,4 @@ jobs:
         run: pnpm build
 
       - name: ʦ ATTW
-        run: pnpm typecheck:attw
+        run: pnpm typecheck:attw --ignore-rules no-resolution

--- a/README.md
+++ b/README.md
@@ -37,10 +37,8 @@ Configure your `root.tsx` to generate a csrf token, and pass it to the client.
 // app/root.tsx
 
 import { json, type LoaderFunctionArgs } from '@remix-run/node';
-import {
-    AuthenticityTokenProvider,
-    verifyAuthenticityToken,
-} from 'remix-session-csrf';
+import { AuthenticityTokenProvider } from 'remix-session-csrf/react';
+import { verifyAuthenticityToken } from 'remix-session-csrf/server';
 import {
     // rest of imports
     useLoaderData,
@@ -79,10 +77,8 @@ Then, add a token and validation to your form + action:
 
 import { type ActionFunctionArgs } from '@remix-run/node';
 import { Form } from '@remix-run/react';
-import { 
-    AuthenticityTokenInput, 
-    verifyAuthenticityToken 
-} from 'remix-session-csrf';
+import { AuthenticityTokenInput } from 'remix-session-csrf/react';
+import { verifyAuthenticityToken } from 'remix-session-csrf/server';
 
 import { getSession } from '~/utils/session.server';
 
@@ -111,10 +107,8 @@ You can also use the `useAuthenticityToken` hook to get the token and validation
 
 import { type ActionFunctionArgs } from '@remix-run/node';
 import { useFetcher } from '@remix-run/react';
-import {
-    useAuthenticityToken,
-    verifyAuthenticityToken,
-} from 'remix-session-csrf';
+import { useAuthenticityToken } from 'remix-session-csrf/react';
+import { verifyAuthenticityToken } from 'remix-session-csrf/server';
 
 import { getSession } from '~/utils/session.server';
 

--- a/package.json
+++ b/package.json
@@ -1,20 +1,28 @@
 {
+  "sideEffects": false,
   "name": "remix-session-csrf",
   "version": "0.1.0",
   "description": "",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
-  "types": "dist/index.d.ts",
   "exports": {
-    ".": {
+    "./server": {
       "types": {
-        "import": "./dist/index.d.mts",
-        "require": "./dist/index.d.ts",
-        "default": "./dist/index.d.mts"
+        "import": "./dist/server.d.mts",
+        "require": "./dist/server.d.ts",
+        "default": "./dist/server.d.mts"
       },
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "default": "./dist/index.mjs"
+      "import": "./dist/server.mjs",
+      "require": "./dist/server.js",
+      "default": "./dist/server.mjs"
+    },
+    "./react": {
+      "types": {
+        "import": "./dist/react.d.mts",
+        "require": "./dist/react.d.ts",
+        "default": "./dist/react.d.mts"
+      },
+      "import": "./dist/react.mjs",
+      "require": "./dist/react.js",
+      "default": "./dist/react.mjs"
     }
   },
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,0 @@
-export * from './react';
-export * from './server';

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig((opts) => ({
-    entry: ['src/index.ts'],
+    entry: ['src/react.tsx', 'src/server.ts'],
     target: 'es2022',
     external: ['react'],
     sourcemap: true,


### PR DESCRIPTION
Requires importing from `remix-session-csrf/server` and `remix-session-csrf/react` instead of `remix-session-csrf`